### PR TITLE
ci: trigger for renovate branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - 'renovate/**'
 
 jobs:
   lint:


### PR DESCRIPTION
To make use of renovate's branch merge strategy, the ci pipeline must run on branches created by renovate.

For branches that open PRs, like branches for which the pipeline fails or which include major updates, the pipeline should run twice with this change. That's not perfect, but as far as I can get it to work for now.