### PR TITLE
fix: prefer #app useHead

### DIFF
--- a/src/runtime/plugins/script.ts
+++ b/src/runtime/plugins/script.ts
@@ -1,5 +1,6 @@
 import type { TurnstileRenderOptions } from '../types'
-import { defineNuxtPlugin, useRuntimeConfig, useHead, ref, isVue2, watch } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig, ref, isVue2, watch } from '#imports'
+import { useHead } from "#app"
 
 const configure = [
   'window.loadTurnstile = new Promise(resolve => {',


### PR DESCRIPTION
Hi :wave: 
This PR resolve #250 

I've been able to reproduce the issue within the playground as stated in a comment. 

⚠️ However, i do have a website which is currently in production with nuxt 3.6.5 WITHOUT this issue which makes me quite nervous if it reveals that the issue only happens for a small fractions of users.

So I noticed that `useHead()` could not `injectHead()` within the turnstile plugin. Switching the `useHead()` from `#app` seems to fix the issue locally for me. 

Another note is that `useHead` from `#app` and `useHead` from `#imports` are not equal, even the body is different.

![image](https://github.com/nuxt-modules/turnstile/assets/63512348/c2ea0025-b7ee-48ca-a97c-369869cdbff0)

(maybe is it a nuxt treeshaking or deps optimization issue ?)

Since this issue is quite bizarre, i have no idea on how to reproduce it on e2e tests.

cc @harlan-zw