### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 
    ```bash
    # Whichever matches your package manager
-   pnpm add -D @nuxtjs/turnstile
-   npm install -D @nuxtjs/turnstile
-   yarn add -D @nuxtjs/turnstile
+   npx nuxi@latest module add turnstile
+   npx nuxi@latest module add turnstile
+   npx nuxi@latest module add turnstile
    ```
 
    ```js

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@
 2. Install and add `@nuxtjs/turnstile` to your `nuxt.config`.
 
    ```bash
-   # Whichever matches your package manager
-   npx nuxi@latest module add turnstile
-   npx nuxi@latest module add turnstile
    npx nuxi@latest module add turnstile
    ```
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
