### PR TITLE
fix: split runtime configuration to avoid override on nuxt-site-config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -64,16 +64,18 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.build.transpile.push(runtimeDir)
 
     // Set up configuration
-    nuxt.options.runtimeConfig = defu(nuxt.options.runtimeConfig, {
-      turnstile: {
+    nuxt.options.runtimeConfig.turnstile = defu(
+      nuxt.options.runtimeConfig.turnstile,
+      {
         secretKey: options.secretKey,
       },
-      public: {
-        turnstile: {
-          siteKey,
-        },
+    )
+    nuxt.options.runtimeConfig.public.turnstile = defu(
+      nuxt.options.runtimeConfig.public.turnstile,
+      {
+        siteKey,
       },
-    })
+    )
 
     // Add plugin to load turnstile script
     addPlugin({ src: join(runtimeDir, 'plugins/script') })

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -45,7 +45,7 @@ export interface TurnstileRenderOptions {
    *
    * @default {`always`}
    */
-  appearance?: 'always' | 'execute' | 'interaction-only';
+  'appearance'?: 'always' | 'execute' | 'interaction-only'
 }
 
 export type TurnstileValidationErrorCode =


### PR DESCRIPTION
Split nuxt.options.runtimeConfig assignment to only target `turnstile` configuration to fix #314 