### PR TITLE
docs(github): correct stackblitz link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
       required: true
     attributes:
       label: 🛠️ To reproduce
-      description: A reproduction of the bug via https://stackblitz.com/github/nuxt-modules/turnstile/tree/main/playground
+      description: A reproduction of the bug via https://stackblitz.com/github/nuxt-modules/turnstile/tree/stackblitz/playground
       placeholder: https://stackblitz.com/[...]
   - type: textarea
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
       required: true
     attributes:
       label: 🛠️ To reproduce
-      description: A reproduction of the bug via https://stackblitz.com/github/nuxt-modules/turnstile/tree/stackblitz/playground
+      description: A reproduction of the bug via https://stackblitz.com/github/nuxt-modules/turnstile/tree/main/playground
       placeholder: https://stackblitz.com/[...]
   - type: textarea
     validations:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) integration for [Nuxt 3](https://v3.nuxtjs.org)
 
 - [✨ &nbsp;Changelog](https://github.com/nuxt-modules/turnstile/blob/main/CHANGELOG.md)
-<!-- - [▶️ &nbsp;Online playground](https://stackblitz.com/github/nuxt-modules/turnstile/tree/main/playground) -->
+- [▶️ &nbsp;Online playground](https://stackblitz.com/github/nuxt-modules/turnstile/tree/stackblitz/playground)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) integration for [Nuxt 3](https://v3.nuxtjs.org)
 
 - [✨ &nbsp;Changelog](https://github.com/nuxt-modules/turnstile/blob/main/CHANGELOG.md)
-- [▶️ &nbsp;Online playground](https://stackblitz.com/github/nuxt-modules/turnstile/tree/stackblitz/playground)
+- [▶️ &nbsp;Online playground](https://stackblitz.com/github/nuxt-modules/turnstile/tree/main/playground)
 
 ## Features
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,7 @@
     "generate": "nuxi generate"
   },
   "devDependencies": {
-    "@nuxtjs/turnstile": "link:..",
+    "@nuxtjs/turnstile": "latest",
     "nuxt": "3.13.1"
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

#318 couldn't add a minimal reproduction as the stackblitz link in the bug report template doesn't work

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've created a `stackblitz` branch, which just replaces

```
"@nuxtjs/turnstile": "link:..",
"nuxt": "3.13.1"
```

with

```
"@nuxtjs/turnstile": "^0.9",
"nuxt": "^3"
```

so that a link to the playground directory in this branch on stackblitz should work again.

Do you have other ideas for a solution @danielroe?

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
