### PR TITLE
chore(component): remove `nextTick`

### DIFF
--- a/src/runtime/components/NuxtTurnstile.vue
+++ b/src/runtime/components/NuxtTurnstile.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useScriptCloudflareTurnstile } from '../composables/turnstile'
-import { nextTick, useRuntimeConfig, ref, onMounted, onBeforeUnmount, useScriptTriggerElement } from '#imports'
+import { useRuntimeConfig, ref, onMounted, onBeforeUnmount, useScriptTriggerElement } from '#imports'
 import type { ElementScriptTrigger } from '#nuxt-scripts'
 
 const props = withDefaults(defineProps<{
@@ -47,8 +47,6 @@ const unmount = () => {
 }
 
 onMounted(async () => {
-  await nextTick() // TODO: remove once upstream vue bug is fixed (https://github.com/vuejs/core/issues/5844, https://github.com/nuxt/nuxt/issues/13471)
-
   id = await render(el.value, {
     sitekey: props.siteKey || config.siteKey,
     callback: (token: string) => emit('update:modelValue', token),


### PR DESCRIPTION
### 🔗 Linked issue

I suggested this earlier in #295 already and we decided to wait for the scripts migration which is now done. The playground demo works without `nextTick` for me. As the upstream issues mentioned in code are resolved, I think we can remove `nextTick` now.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Removes a `await nextTick` that does not appear to be required anymore.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
