### PR TITLE
fix(types): ensure `Turnstile` type namespace is registered

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
+    "@types/cloudflare-turnstile": "0.2.2",
     "@nuxt/kit": "^3.13.1",
     "defu": "^6.1.4",
     "pathe": "^1.1.2"
@@ -63,7 +64,6 @@
     "@nuxt/schema": "3.13.2",
     "@nuxt/scripts": "0.9.2",
     "@nuxt/test-utils": "3.14.2",
-    "@types/cloudflare-turnstile": "0.2.2",
     "@types/node": "22.5.5",
     "@vitest/coverage-v8": "2.1.1",
     "bumpp": "9.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@nuxt/kit':
         specifier: ^3.13.1
         version: 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@types/cloudflare-turnstile':
+        specifier: 0.2.2
+        version: 0.2.2
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -37,9 +40,6 @@ importers:
       '@nuxt/test-utils':
         specifier: 3.14.2
         version: 3.14.2(h3@1.12.0)(magicast@0.3.5)(nitropack@2.9.7(magicast@0.3.5)(webpack-sources@3.2.3))(playwright-core@1.47.1)(rollup@3.29.4)(vite@5.4.5(@types/node@22.5.5)(terser@5.32.0))(vitest@2.1.1(@types/node@22.5.5)(terser@5.32.0))(vue-router@4.4.5(vue@3.5.5(typescript@5.6.2)))(vue@3.5.5(typescript@5.6.2))(webpack-sources@3.2.3)
-      '@types/cloudflare-turnstile':
-        specifier: 0.2.2
-        version: 0.2.2
       '@types/node':
         specifier: 22.5.5
         version: 22.5.5

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,7 @@ import {
   addImports,
   addComponent,
   installModule,
-  addTypeTemplate
+  addTypeTemplate,
 } from '@nuxt/kit'
 import { join, resolve } from 'pathe'
 import { defu } from 'defu'

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,6 +7,7 @@ import {
   addImports,
   addComponent,
   installModule,
+  addTypeTemplate
 } from '@nuxt/kit'
 import { join, resolve } from 'pathe'
 import { defu } from 'defu'
@@ -122,6 +123,11 @@ export default defineNuxtModule<ModuleOptions>({
           },
         ],
       })
+    })
+
+    addTypeTemplate({
+      filename: 'types/cloudflare-turnstile.d.ts',
+      getContents: () => `/// <reference types="@types/cloudflare-turnstile" />`,
     })
   },
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,6 @@ import {
   addImports,
   addComponent,
   installModule,
-  addTypeTemplate,
 } from '@nuxt/kit'
 import { join, resolve } from 'pathe'
 import { defu } from 'defu'

--- a/src/module.ts
+++ b/src/module.ts
@@ -125,9 +125,9 @@ export default defineNuxtModule<ModuleOptions>({
       })
     })
 
-    addTypeTemplate({
-      filename: 'types/cloudflare-turnstile.d.ts',
-      getContents: () => `/// <reference types="@types/cloudflare-turnstile" />`,
+    nuxt.hook('prepare:types', ({ references }) => {
+      references.push({ types: '@types/cloudflare-turnstile' })
     })
+    nuxt.options.typescript.hoist.push('@types/cloudflare-turnstile')
   },
 })

--- a/src/runtime/composables/turnstile.ts
+++ b/src/runtime/composables/turnstile.ts
@@ -1,4 +1,3 @@
-/// <reference types="@types/cloudflare-turnstile" />
 import { useRegistryScript } from '#nuxt-scripts-utils'
 import type { RegistryScriptInput } from '#nuxt-scripts'
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #336 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes the Cloudflare turnstile namespace typecheck in a fresh install (deleting `node_modules` and `package-lock.json`)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
