### PR TITLE
chore(pnpm): ignore built dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
-  - "playground"
+  - playground
+ignoredBuiltDependencies:
+  - '@parcel/watcher'
+  - esbuild


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

pnpm v10 asks if two dependencies should be allowed to execute scripts on installation. I think both scripts don't need to be executed so this PR adds them to a ignore list. With this PR pnpm won't ask to run `pnpm approve` again until something changes about the scripts our dependencies may run.