### PR TITLE
perf: add support for abort signals

### DIFF
--- a/src/runtime/server/utils/verify.ts
+++ b/src/runtime/server/utils/verify.ts
@@ -9,6 +9,7 @@ const endpoint = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
 export const verifyTurnstileToken = async (
   token: string,
   event?: H3Event,
+  signal?: AbortSignal
 ): Promise<TurnstileValidationResponse> => {
   const secretKey = useRuntimeConfig(event).turnstile.secretKey
   return await $fetch(endpoint, {
@@ -17,5 +18,6 @@ export const verifyTurnstileToken = async (
     headers: {
       'content-type': 'application/x-www-form-urlencoded',
     },
+    signal
   })
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Adding signal for the verification allows end-developers to cancel the request, if, for example, the client closes the request before the fetch finishes. As this is an external request, which involves network traffic, this can be more resource-efficient.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
