### PR TITLE
fix: error on some nuxt 4 builds due to missing `.vue` extension

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -98,7 +98,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     addComponent({
       name: 'NuxtTurnstile',
-      filePath: join(runtimeDir, 'components', 'NuxtTurnstile'),
+      filePath: join(runtimeDir, 'components', 'NuxtTurnstile.vue'),
     })
 
     if (options.addValidateEndpoint) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR fixes an issue with this modules `addComponent` call. The [documentation](https://nuxt.com/docs/4.x/guide/going-further/modules#injecting-vue-components-with-addcomponent) for modules seems to suggest that the file path for such calls should include the extension `.vue` which this didn't.

Adding this extension seems to fix the following build issue on one of our Nuxt 4 applications. It seems that this didn't affect all v4 instances and I presume it was something to do with package version issues but I believe this change may have been necessary anyway?

This is the error we get during build. Works fine in dev:
```bash
[10:42:33 AM]  ERROR  Cannot find module /Users/i33672/Developer/customer-portal/node_modules/.pnpm/@nuxtjs+turnstile@1.1.0_@nuxt+scripts@0.11.10_@azure+identity@4.12.0_@azure+storage-blo_d2f4d68acc0b28be5fbe4ca80e75a122/node_modules/@nuxtjs/turnstile/dist/runtime/components/NuxtTurnstile imported from file:///Users/i33672/Developer/customer-portal/apps/customer-portal, file:///Users/i33672/Developer/customer-portal/apps/, file:///Users/i33672/Developer/customer-portal/apps/customer-portal/_index.js, file:///Users/i33672/Developer/customer-portal/apps/node_modules

    at _resolve (/Users/i33672/Developer/customer-portal/node_modules/.pnpm/mlly@1.8.0/node_modules/mlly/dist/index.mjs:2101:19)
    at resolveSync (/Users/i33672/Developer/customer-portal/node_modules/.pnpm/mlly@1.8.0/node_modules/mlly/dist/index.mjs:2110:10)
    at resolvePathSync (/Users/i33672/Developer/customer-portal/node_modules/.pnpm/mlly@1.8.0/node_modules/mlly/dist/index.mjs:2120:24)
    at useComponentMetaParser (/Users/i33672/Developer/customer-portal/node_modules/.pnpm/nuxt-component-meta@0.10.1_magicast@0.3.5/node_modules/nuxt-component-meta/dist/parser.mjs:45:22)
    at /Users/i33672/Developer/customer-portal/node_modules/.pnpm/nuxt-component-meta@0.10.1_magicast@0.3.5/node_modules/nuxt-component-meta/dist/module.mjs:212:16
    at async /Users/i33672/Developer/customer-portal/node_modules/.pnpm/nuxt@4.1.0_@azure+identity@4.12.0_@azure+storage-blob@12.28.0_@parcel+watcher@2.5.1_@ty_63dd905ecca3c63e87da58fb6b19210f/node_modules/nuxt/dist/index.mjs:3464:7
    at async generateApp (/Users/i33672/Developer/customer-portal/node_modules/.pnpm/nuxt@4.1.0_@azure+identity@4.12.0_@azure+storage-blob@12.28.0_@parcel+watcher@2.5.1_@ty_63dd905ecca3c63e87da58fb6b19210f/node_modules/nuxt/dist/index.mjs:6669:3)
    at async _applyPromised (/Users/i33672/Developer/customer-portal/node_modules/.pnpm/perfect-debounce@2.0.0/node_modules/perfect-debounce/dist/index.mjs:85:9) 



[10:42:33 AM]  ERROR  Cannot find module /Users/i33672/Developer/customer-portal/node_modules/.pnpm/@nuxtjs+turnstile@1.1.0_@nuxt+scripts@0.11.10_@azure+identity@4.12.0_@azure+storage-blo_d2f4d68acc0b28be5fbe4ca80e75a122/node_modules/@nuxtjs/turnstile/dist/runtime/components/Nu
```

Nuxi info:
```bash
- Operating System: `Darwin`
- Node Version:     `v22.16.0`
- Nuxt Version:     `4.1.0`
- CLI Version:      `3.29.1`
- Nitro Version:    `2.12.5`
- Package Manager:  `pnpm@10.15.1`
- Builder:          `-`
- User Config:      `modules`, `compatibilityDate`, `runtimeConfig`, `typescript`, `alias`, `devtools`, `vite`, `nitro`, `css`, `sourcemap`, `build`, `imports`, `devServer`, `experimental`, `routeRules`, `fonts`, `content`, `eslint`, `sentry`
- Runtime Modules:  `@nuxtjs/robots@5.5.1`, `@vueuse/nuxt@13.9.0`, `@nuxt/icon@1.15.0`, `@nuxt/fonts@0.11.4`, `@nuxt/image@1.11.0`, `@nuxt/scripts@0.11.10`, `@nuxt/content@3.4.0`, `@nuxt/eslint@1.9.0`, `@nuxt/test-utils/module@3.19.2`, `@sentry/nuxt/module@10.18.0`, `@nuxtjs/turnstile@1.1.0`
- Build Modules:    `-`
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
